### PR TITLE
Fix skip ahead.

### DIFF
--- a/manifesttool/parse.py
+++ b/manifesttool/parse.py
@@ -30,7 +30,7 @@ def skipAhead(code):
         rc = 2
     if code == 0x83:
         rc = 3
-    if code == 0x83:
+    if code == 0x84:
         rc = 4
     return rc
 


### PR DESCRIPTION
`code = 0x83` check is duplicated, which will cause issues when the code is 0x83 or 0x84.