### PR TITLE
Change default certificate duration to 30y

### DIFF
--- a/manifesttool/defaults.py
+++ b/manifesttool/defaults.py
@@ -20,7 +20,7 @@ import os
 certificatePath = '.update-certificates'
 certificate = os.path.join(certificatePath,'default.der')
 certificateKey = os.path.join(certificatePath,'default.key.pem')
-certificateDuration = 90
+certificateDuration = 30*365
 pskMasterKey = os.path.join(certificatePath,'default.master.psk')
 config = '.manifest_tool.json'
 cloud_config = '.mbed_cloud_config.json'


### PR DESCRIPTION
Instead of the extremely short 90 days. This has caused multiple issues.